### PR TITLE
Code cleanup, lava lamp dividers, and styling polish

### DIFF
--- a/app/components/leftSide/heading/Heading.tsx
+++ b/app/components/leftSide/heading/Heading.tsx
@@ -33,9 +33,10 @@ export const Heading = () => {
                 <motion.div
                 whileHover={{ scale: 1.1, y: -2 }}>
                     <p
-                    onClick={scrollToTop} 
+                    onClick={scrollToTop}
                     style={{
                         fontSize: isMobile ? 32 : 48,
+                        fontWeight: 600,
                         cursor: 'pointer',
                         marginLeft: '30px'
 
@@ -51,7 +52,7 @@ export const Heading = () => {
     (
     <div className={styles.heading}>
         <div>
-            <p style={{ fontSize: 48 }}>Dylan Toporek</p>
+            <p style={{ fontSize: 48, fontWeight: 600 }}>Dylan Toporek</p>
         </div>
 
         <div>

--- a/app/components/leftSide/navElements/NavElements.tsx
+++ b/app/components/leftSide/navElements/NavElements.tsx
@@ -84,7 +84,7 @@ const handleScroll = (section: string) => {
           onClick={() => handleScroll(section)}
           style={{
             cursor: "pointer",
-            color: activeSection === section || target === section ? "#AAB2C6" : "#fff", // Highlight active section
+            color: activeSection === section || target === section ? "#FF6F61" : "#fff", // Highlight active section
           }}
         >
           <Line isHovered={hover && target === section} />

--- a/app/components/leftSide/socialLinks/SocialLinks.tsx
+++ b/app/components/leftSide/socialLinks/SocialLinks.tsx
@@ -36,13 +36,10 @@ export const SocialLinks = () => {
       }
 
       function handleColor(method: string){
-        if (isMobile){
-          if (isHovered === method){
-            return 'black'
-          } else return '#4B88A2'
-        } else if (isHovered === method){
-          return 'white'
-        } else return '#4B88A2'
+        if (isHovered === method){
+          return '#FF6F61'
+        }
+        return '#4B88A2'
       }
     return (
         <div 

--- a/app/components/line/Line.tsx
+++ b/app/components/line/Line.tsx
@@ -5,7 +5,7 @@ export const Line = ({isHovered}: {isHovered: boolean}) => {
     return (
         <div className={styles.line}
         style={{
-            background: isHovered ? 'white' : '#4B88A2'
+            background: isHovered ? '#FF6F61' : '#4B88A2'
         }}>
 
         </div>

--- a/app/components/rightSide/Projects/Project.tsx
+++ b/app/components/rightSide/Projects/Project.tsx
@@ -34,24 +34,37 @@ export const Project = ({ project }: Props) => {
         }}>
             <div
              style={{
-                width: "100%", // Takes up half the width
+                width: "100%",
                 maxWidth: '250px',
-                maxHeight: '250px',
-                height: "auto", // Takes up half the parent div height
+                aspectRatio: '1 / 1', // Uniform square frame regardless of source image shape
                 display: "flex",
                 justifyContent: "center",
                 alignItems: "center",
-                // overflow: "none",
+                padding: '12px',
+                borderRadius: '16px',
+                border: '1px solid rgba(255, 255, 255, 0.1)',
+                background: 'rgba(255, 255, 255, 0.05)',
+                flexShrink: 0,
              }}>
-                <a href={project.url} style={{display: "table-cell"}} target="_blank">
-                    <img
+                <a
+                    href={project.url}
+                    target="_blank"
                     style={{
-                        width: "100%", // Ensures it fully fills the div horizontally
-                        height: "100%", // Ensures it fully fills the div vertically
-                        objectFit: "contain" // Ensures no stretching
-                    }} src={project.image}/> 
+                        display: 'flex',
+                        width: '100%',
+                        height: '100%',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                    }}>
+                    <img
+                    alt={project.title}
+                    style={{
+                        maxWidth: "100%",
+                        maxHeight: "100%",
+                        objectFit: "contain", // Ensures no stretching or cropping
+                        borderRadius: '8px',
+                    }} src={project.image}/>
                 </a>
-                
             </div>
             <div
             style={{

--- a/app/components/rightSide/experience/Experience.tsx
+++ b/app/components/rightSide/experience/Experience.tsx
@@ -141,11 +141,13 @@ export const Experience = () => {
                     key={job.id}
                     initial={{ opacity: 0, y: 20 }}
                     whileInView={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.6 }}
+                    whileHover={{ backgroundColor: 'rgba(255, 255, 255, 0.18)' }}
+                    transition={{ duration: 0.6, backgroundColor: { duration: 0.2 } }}
                     style={{
-                        background: 'rgba(255, 255, 255, 0.1)',
+                        backgroundColor: 'rgba(255, 255, 255, 0.1)',
                         padding: '8px',
-                        borderRadius: '16px'
+                        borderRadius: '16px',
+                        cursor: 'pointer'
                     }}
                     >
                         <Job job={job}/>

--- a/app/components/sideMenu.tsx
+++ b/app/components/sideMenu.tsx
@@ -152,12 +152,13 @@ const SideMenu = () => {
             <motion.div
               key={id}
               onClick={() => handleScroll(id)}
-              className={`cursor-pointer text-lg p-2 transition ${
-                activeSection === id ? "#FF6F61" : "text-white"
-              }`}
               whileHover={{ y: -2, scale: 1.1 }}
               style={{
-                cursor: 'pointer'
+                cursor: 'pointer',
+                fontSize: '18px',
+                padding: '8px',
+                color: activeSection === id ? '#FF6F61' : 'black',
+                transition: 'color 0.2s ease'
               }}
             >
               {label}

--- a/app/styles/rightSide.module.css
+++ b/app/styles/rightSide.module.css
@@ -22,6 +22,10 @@
     }
 }
 
+.about {
+    line-height: 1.6;
+}
+
 .experience {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

Three rounds of work on the portfolio, verified live in the browser at each step (type-check, production build, and desktop/mobile screenshots):

### 1. Code cleanup (no visual changes)
- Removed unused Redux boilerplate left from the Next.js template: `/quotes`, `/verify`, the Counter widget, `StoreProvider`, and the whole `lib/` store
- Deleted dead files (`Nav.tsx`, `hamburgerIcon.tsx`, `divider.tsx`, unused CSS module, unreferenced images in `public/`)
- Extracted the `isMobile` detection duplicated across ~9 components into a shared `useIsMobile` hook
- Replaced `any`/`@ts-ignore` with proper types (`JobDetails`, `ProjectDetails` interfaces)
- Fixed React key-prop warnings in `Experience`/`Projects` (key was on the inner child instead of the mapped element)
- Dropped now-unused dependencies: Chakra UI, Emotion, Redux Toolkit, react-redux, Tailwind, PostCSS, gsap, react-device-detect

### 2. Lava lamp section dividers
- Replaced the wave dividers with a lava-lamp animation: blobs rise out of a molten pool, drift, and sink back, merging through an SVG gooey filter
- Built with framer-motion (already a dependency); fixed blob positions instead of `Math.random()`, which also eliminates the hydration mismatch the old Wave caused
- Filter/gradient ids generated with `useId` since the component renders twice per page
- Same palette as before (#AAB2C6 → deep navy), desktop-only like the waves were

### 3. Styling polish
- Name heading bumped to weight 600
- Coral (#FF6F61) as the single accent for active/hover states: nav links, section lines, social icons, mobile side menu (fixing leftover broken Tailwind classes there)
- Experience cards lighten on hover to signal they expand
- Project images in uniform square framed cards; added alt text
- About paragraphs get 1.6 line-height

## Testing
- `tsc --noEmit` clean
- `next build` succeeds
- Verified in headless Chromium: desktop + mobile layouts, divider animation frames, hover/active states, no console errors or hydration warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_