### PR TITLE
Redesign mobile navigation

### DIFF
--- a/app/components/leftSide/heading/Heading.tsx
+++ b/app/components/leftSide/heading/Heading.tsx
@@ -28,26 +28,26 @@ export const Heading = () => {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
-                    borderBottom: '1px solid white',
+                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.35)',
+                    padding: '14px 0',
                 }}
             >
-                <motion.div whileHover={{ scale: 1.1, y: -2 }}>
+                <motion.div whileHover={{ scale: 1.05, y: -2 }}>
                     <button
                         type="button"
                         onClick={scrollToTop}
                         aria-label="Scroll to top"
                         style={{
-                            fontSize: isMobile ? 32 : 48,
+                            fontSize: 26,
                             fontWeight: 600,
                             cursor: 'pointer',
-                            marginLeft: '30px',
+                            marginLeft: '20px',
                             background: 'none',
                             border: 'none',
                             color: 'inherit',
                             fontFamily: 'inherit',
                             padding: 0,
-                            marginTop: '1em',
-                            marginBottom: '1em',
                         }}
                     >
                         Dylan Toporek

--- a/app/components/leftSide/socialLinks/SocialLinks.tsx
+++ b/app/components/leftSide/socialLinks/SocialLinks.tsx
@@ -46,8 +46,8 @@ export const SocialLinks = () => {
             className={styles.socials}
             style={{
                 display: 'flex',
-                flexDirection: isMobile ? 'column' : 'row',
-                gap: isMobile ? 30 : '10%',
+                flexDirection: 'row',
+                gap: isMobile ? 32 : '10%',
             }}
         >
             {contactMethods.map((method) => {

--- a/app/components/sideMenu.tsx
+++ b/app/components/sideMenu.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { SocialLinks } from './leftSide/socialLinks/SocialLinks'
 const navItems = [
     { id: 'about', label: 'About' },
@@ -15,15 +15,12 @@ const SideMenu = () => {
     // Toggle Menu
     const toggleMenu = () => setIsOpen(!isOpen)
 
-    // Close menu when clicking outside
+    // Lock body scroll while the menu is open
     useEffect(() => {
-        const handleClickOutside = (e: MouseEvent) => {
-            if (isOpen && !(e.target as HTMLElement).closest('#side-menu')) {
-                setIsOpen(false)
-            }
+        document.body.style.overflow = isOpen ? 'hidden' : ''
+        return () => {
+            document.body.style.overflow = ''
         }
-        document.addEventListener('click', handleClickOutside)
-        return () => document.removeEventListener('click', handleClickOutside)
     }, [isOpen])
 
     // Handle scrolling to section
@@ -72,134 +69,169 @@ const SideMenu = () => {
     }, [])
 
     return (
-        <motion.div
+        <div
             style={{
-                marginRight: '30px',
+                marginRight: '20px',
             }}
         >
             {/* Hamburger Button */}
-            {!isOpen && (
-                <motion.div whileHover={{ y: -2, scale: 1.1 }}>
-                    <button
-                        onClick={toggleMenu}
-                        aria-label="Open navigation menu"
-                        aria-expanded={isOpen}
-                        style={{
-                            background: 'transparent',
-                            border: 'none',
-                            cursor: 'pointer',
-                        }}
-                    >
-                        <svg
-                            width="32"
-                            height="32"
-                            viewBox="0 0 24 24"
-                            stroke="white"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            aria-hidden="true"
-                        >
-                            <line x1="3" y1="6" x2="21" y2="6" />
-                            <line x1="3" y1="12" x2="21" y2="12" />
-                            <line x1="3" y1="18" x2="21" y2="18" />
-                        </svg>
-                    </button>
-                </motion.div>
-            )}
-
-            {/* Side Menu */}
-            <motion.div
-                id="side-menu"
-                initial={{ x: '100%' }} // Start the menu off-screen to the right
-                animate={{ x: isOpen ? '0%' : '100%' }} // Slide in when open, slide out when closed
-                transition={{ type: 'spring', stiffness: 300, damping: 30 }} // Smooth spring animation
-                style={{
-                    transformOrigin: 'right', // Ensure the animation starts from the right
-                    zIndex: 40, // Ensure the side menu stays on top of other content
-                    position: 'fixed',
-                    top: 0,
-                    right: 0, // Fix the menu to the right side
-                    height: '100%',
-                    padding: '8px',
-                    backgroundColor: '#AAB2C6', // Adjusted to gray for better visibility
-                    color: 'black',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 50, // Adjust gap if needed
-                    minWidth: '150px', // Set a minimum width for the side menu
-                }}
-            >
-                <motion.div
-                    whileHover={{ y: -2, scale: 1.1 }}
+            <motion.div whileHover={{ y: -2, scale: 1.1 }}>
+                <button
+                    onClick={toggleMenu}
+                    aria-label="Open navigation menu"
+                    aria-expanded={isOpen}
                     style={{
-                        alignSelf: 'end',
-                        marginTop: '10px',
-                    }}
-                >
-                    <button
-                        onClick={toggleMenu}
-                        aria-label="Close navigation menu"
-                        style={{
-                            background: 'transparent',
-                            border: 'none',
-                            color: 'black',
-                            cursor: 'pointer',
-                            fontSize: '20px',
-                        }}
-                    >
-                        ✕
-                    </button>
-                </motion.div>
-
-                <div
-                    style={{
-                        height: '100%',
+                        background: 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        padding: '8px',
                         display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
                     }}
                 >
-                    <nav
-                        aria-label="Section navigation"
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            gap: 30, // Adjust space between links
-                        }}
+                    <svg
+                        width="28"
+                        height="28"
+                        viewBox="0 0 24 24"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        aria-hidden="true"
                     >
-                        {navItems.map(({ id, label }) => (
-                            <motion.button
-                                key={id}
-                                type="button"
-                                onClick={() => handleScroll(id)}
-                                whileHover={{ y: -2, scale: 1.1 }}
-                                aria-current={
-                                    activeSection === id ? 'true' : undefined
-                                }
+                        <line x1="3" y1="6" x2="21" y2="6" />
+                        <line x1="3" y1="12" x2="21" y2="12" />
+                        <line x1="3" y1="18" x2="21" y2="18" />
+                    </svg>
+                </button>
+            </motion.div>
+
+            <AnimatePresence>
+                {isOpen && (
+                    <>
+                        {/* Dimmed backdrop */}
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.25 }}
+                            onClick={() => setIsOpen(false)}
+                            style={{
+                                position: 'fixed',
+                                inset: 0,
+                                backgroundColor: 'rgba(4, 10, 18, 0.6)',
+                                backdropFilter: 'blur(2px)',
+                                zIndex: 39,
+                            }}
+                        />
+
+                        {/* Side Menu */}
+                        <motion.div
+                            id="side-menu"
+                            role="dialog"
+                            aria-label="Navigation menu"
+                            initial={{ x: '100%' }}
+                            animate={{ x: 0 }}
+                            exit={{ x: '100%' }}
+                            transition={{
+                                type: 'spring',
+                                stiffness: 300,
+                                damping: 30,
+                            }}
+                            style={{
+                                zIndex: 40,
+                                position: 'fixed',
+                                top: 0,
+                                right: 0,
+                                height: '100%',
+                                width: 'min(280px, 80vw)',
+                                padding: '16px 24px 32px',
+                                backgroundColor: '#132435',
+                                borderLeft:
+                                    '1px solid rgba(255, 255, 255, 0.1)',
+                                boxShadow: '-16px 0 40px rgba(0, 0, 0, 0.5)',
+                                color: '#F5F5F4',
+                                display: 'flex',
+                                flexDirection: 'column',
+                            }}
+                        >
+                            <button
+                                onClick={toggleMenu}
+                                aria-label="Close navigation menu"
                                 style={{
-                                    cursor: 'pointer',
-                                    fontSize: '18px',
-                                    padding: '8px',
-                                    background: 'none',
+                                    alignSelf: 'flex-end',
+                                    background: 'transparent',
                                     border: 'none',
-                                    fontFamily: 'inherit',
-                                    color:
-                                        activeSection === id
-                                            ? '#FF6F61'
-                                            : 'black',
-                                    transition: 'color 0.2s ease',
+                                    color: '#AAB2C6',
+                                    cursor: 'pointer',
+                                    fontSize: '24px',
+                                    padding: '8px',
+                                    lineHeight: 1,
                                 }}
                             >
-                                {label}
-                            </motion.button>
-                        ))}
-                    </nav>
-                    <SocialLinks />
-                </div>
-            </motion.div>
-        </motion.div>
+                                ✕
+                            </button>
+
+                            <nav
+                                aria-label="Section navigation"
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    marginTop: '24px',
+                                    gap: '8px',
+                                }}
+                            >
+                                {navItems.map(({ id, label }) => (
+                                    <button
+                                        key={id}
+                                        type="button"
+                                        onClick={() => handleScroll(id)}
+                                        aria-current={
+                                            activeSection === id
+                                                ? 'true'
+                                                : undefined
+                                        }
+                                        style={{
+                                            cursor: 'pointer',
+                                            fontSize: '20px',
+                                            textAlign: 'left',
+                                            padding: '14px 16px',
+                                            borderRadius: '12px',
+                                            background:
+                                                activeSection === id
+                                                    ? 'rgba(255, 255, 255, 0.08)'
+                                                    : 'none',
+                                            border: 'none',
+                                            fontFamily: 'inherit',
+                                            fontWeight: 300,
+                                            color:
+                                                activeSection === id
+                                                    ? '#FF6F61'
+                                                    : '#F5F5F4',
+                                            transition:
+                                                'color 0.2s ease, background 0.2s ease',
+                                        }}
+                                    >
+                                        {label}
+                                    </button>
+                                ))}
+                            </nav>
+
+                            <div
+                                style={{
+                                    marginTop: 'auto',
+                                    paddingTop: '24px',
+                                    borderTop:
+                                        '1px solid rgba(255, 255, 255, 0.1)',
+                                    display: 'flex',
+                                    justifyContent: 'center',
+                                }}
+                            >
+                                <SocialLinks />
+                            </div>
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Summary

The mobile menu previously opened as a flat light-grey panel with black text that clashed with the dark site. This redesigns it to match the site's visual language:

- **Panel**: dark navy (`#132435`) with a hairline border and soft shadow; width capped at `min(280px, 80vw)`
- **Nav items**: large left-aligned tap targets with the active section shown in coral on a soft highlight pill
- **Backdrop**: dimmed + blurred overlay behind the panel; tapping it closes the menu, and body scroll locks while open
- **Social links**: horizontal row under a hairline divider at the panel bottom (was a cramped vertical stack)
- **Exit animation**: panel mounts through `AnimatePresence`, so the slide/fade animates on close too (previously it just vanished)
- **Top bar**: subtle translucent hairline + soft shadow instead of the solid white border, tighter height

## Testing
- Verified with before/after screenshots at 390×844: closed bar, open menu, backdrop dimming, coral active state
- `npm run lint`, `npm run typecheck` clean; 4/4 Playwright smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_