### PR TITLE
Unify nav styling and fix scroll-to-section alignment

### DIFF
--- a/app/components/leftSide/navElements/NavElements.tsx
+++ b/app/components/leftSide/navElements/NavElements.tsx
@@ -47,26 +47,13 @@ export const NavElements = () => {
     const handleScroll = (section: string) => {
         setActiveSection(section)
 
+        // "About" is the first section, so go to the very top of the page;
+        // the others land per the sections' scroll-margin-top
         if (section === 'about') {
             window.scrollTo({ top: 0, behavior: 'smooth' })
+            return
         }
-        // Get the section element
-        const el = document.getElementById(section)
-        if (!el) return
-
-        // Calculate the position of the element
-        const elementPosition =
-            el.getBoundingClientRect().top + window.pageYOffset
-
-        // Calculate the center of the viewport and the element
-        const windowHeight = window.innerHeight
-        const centerPosition = elementPosition - windowHeight / 5.5
-
-        // Scroll to the section and center it
-        window.scrollTo({
-            top: centerPosition,
-            behavior: 'smooth', // Smooth scroll effect
-        })
+        document.getElementById(section)?.scrollIntoView({ behavior: 'smooth' })
     }
 
     return isMobile ? null : (
@@ -92,6 +79,12 @@ export const NavElements = () => {
                     }
                     style={{
                         cursor: 'pointer',
+                        // Same active treatment as the mobile menu:
+                        // coral text on a soft highlight pill
+                        background:
+                            activeSection === section
+                                ? 'rgba(255, 255, 255, 0.08)'
+                                : 'none',
                         color:
                             activeSection === section || target === section
                                 ? '#FF6F61'

--- a/app/components/sideMenu.tsx
+++ b/app/components/sideMenu.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { SocialLinks } from './leftSide/socialLinks/SocialLinks'
 const navItems = [
@@ -11,41 +11,42 @@ const navItems = [
 const SideMenu = () => {
     const [isOpen, setIsOpen] = useState(false)
     const [activeSection, setActiveSection] = useState('about')
+    // Section to scroll to once the menu closes — scrolling can't happen
+    // while the body scroll lock is still active
+    const pendingSection = useRef<string | null>(null)
 
     // Toggle Menu
     const toggleMenu = () => setIsOpen(!isOpen)
 
-    // Lock body scroll while the menu is open
+    // Lock body scroll while the menu is open, and perform any deferred
+    // section scroll once the lock is released
     useEffect(() => {
         document.body.style.overflow = isOpen ? 'hidden' : ''
+
+        if (!isOpen && pendingSection.current) {
+            const section = pendingSection.current
+            pendingSection.current = null
+
+            // "About" is the first section, so go to the very top;
+            // the others land per the sections' scroll-margin-top
+            if (section === 'about') {
+                window.scrollTo({ top: 0, behavior: 'smooth' })
+            } else {
+                document
+                    .getElementById(section)
+                    ?.scrollIntoView({ behavior: 'smooth' })
+            }
+        }
+
         return () => {
             document.body.style.overflow = ''
         }
     }, [isOpen])
 
-    // Handle scrolling to section
+    // Close the menu and scroll to the section once the lock releases
     const handleScroll = (section: string) => {
+        pendingSection.current = section
         setIsOpen(false)
-
-        // Get the section element
-        const el = document.getElementById(section)
-        if (!el) return
-
-        // Calculate the position of the element and its height
-        const elementPosition =
-            el.getBoundingClientRect().top + window.pageYOffset
-        const elementHeight = el.offsetHeight
-
-        // Calculate the center of the viewport and the element
-        const windowHeight = window.innerHeight
-        const centerPosition =
-            elementPosition - windowHeight / 4 + elementHeight / 2
-
-        // Scroll to the section and center it
-        window.scrollTo({
-            top: centerPosition,
-            behavior: 'smooth', // Smooth scroll effect
-        })
     }
 
     // Detect active section while scrolling

--- a/app/styles/leftSide.module.css
+++ b/app/styles/leftSide.module.css
@@ -34,7 +34,8 @@
 .nav_elements {
     display: flex;
     flex-direction: column;
-    gap: 15px;
+    align-items: flex-start;
+    gap: 8px;
     margin-bottom: 20px;
 }
 
@@ -43,22 +44,19 @@
     gap: 15px;
     align-items: center;
     color: #4b88a2;
-    font-size: 16px;
-    max-width: 40%;
+    font-size: 18px;
     background: none;
     border: none;
-    padding: 0;
+    border-radius: 12px;
+    padding: 12px 16px;
     font-family: inherit;
     font-weight: inherit;
     text-align: left;
-
-    &:hover {
-        color: white;
-    }
+    transition: background 0.2s ease;
 }
 
 .line {
-    width: 20%;
+    width: 30px;
     height: 2px;
 }
 

--- a/app/styles/rightSide.module.css
+++ b/app/styles/rightSide.module.css
@@ -11,6 +11,12 @@
     gap: 80px;
 }
 
+/* Landing offset for nav scroll: keeps section headings comfortably below
+   the top of the viewport (and clear of the fixed header on mobile) */
+.right section {
+    scroll-margin-top: 18vh;
+}
+
 /* Mobile styles */
 @media (max-width: 767px) {
     .right {
@@ -19,6 +25,10 @@
         padding: 20px;
         margin-left: 0;
         height: unset;
+    }
+
+    .right section {
+        scroll-margin-top: 84px;
     }
 }
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -36,6 +36,29 @@ test('section navigation scrolls the page', async ({ page }) => {
     expect(scrollY).toBeGreaterThan(0)
 })
 
+test.describe('mobile viewport', () => {
+    test.use({ viewport: { width: 390, height: 844 } })
+
+    test('menu navigation lands sections below the fixed header', async ({
+        page,
+    }) => {
+        await page.goto('/')
+
+        await page.getByRole('button', { name: 'Open navigation menu' }).click()
+        await page.getByRole('button', { name: 'Experience' }).click()
+        await page.waitForTimeout(1500) // menu close + smooth scroll
+
+        const sectionTop = await page.evaluate(
+            () =>
+                document.getElementById('experience')!.getBoundingClientRect()
+                    .top
+        )
+        // Fixed header is ~73px tall; scroll-margin-top places sections at 84px
+        expect(sectionTop).toBeGreaterThan(73)
+        expect(sectionTop).toBeLessThan(150)
+    })
+})
+
 test('unknown routes show the custom 404 page', async ({ page }) => {
     await page.goto('/this-page-does-not-exist')
 


### PR DESCRIPTION
## Summary

Two related navigation improvements:

### Desktop nav matches the mobile menu
The desktop section nav now uses the same active treatment as the redesigned mobile menu: coral text on a soft rounded highlight pill, with larger padded tap targets (18px text, 12px radius). The line indicator stays.

### Scroll-to-section rebuilt for both navs
The old manual offset math (`elementPosition - windowHeight/4 + elementHeight/2` on mobile) overshot for tall sections and ignored the fixed header. Both navs now use `scrollIntoView` with `scroll-margin-top` on the sections:
- **Desktop**: `18vh` — lands sections at the same position as before (measured 162px on a 900px viewport, matching the old `windowHeight/5.5` feel)
- **Mobile**: `84px` — clears the ~73px fixed header with breathing room

Also fixes a subtle mobile bug: the menu scrolled while the body scroll lock was still active, so the scroll could be swallowed. The target section is now stored in a ref and scrolled to in the same effect that releases the lock.

## Testing
- Measured landing positions with Playwright at both viewports: desktop = 162px (exactly 18vh), mobile = 84px (below the 73px header)
- New mobile-viewport regression test asserting sections land below the fixed header
- 5/5 smoke tests passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_