### PR TITLE
Light/dark theme, active-nav tracking fix, and top-aligned scroll landing

### DIFF
--- a/app/components/home/Home.tsx
+++ b/app/components/home/Home.tsx
@@ -2,11 +2,28 @@
 import { MotionConfig } from 'framer-motion'
 import { LeftSide } from '../leftSide/LeftSide'
 import { RightSide } from '../rightSide/RightSide'
+import { ThemeToggle } from '../themeToggle'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import styles from '../../styles/home.module.css'
 
 export const Home = () => {
+    const isMobile = useIsMobile()
+
     return (
         <MotionConfig reducedMotion="user">
+            {/* On mobile the toggle lives in the fixed header bar instead */}
+            {isMobile ? null : (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: '24px',
+                        right: '24px',
+                        zIndex: 20,
+                    }}
+                >
+                    <ThemeToggle />
+                </div>
+            )}
             <div className={styles.home}>
                 <LeftSide />
                 <RightSide />

--- a/app/components/lavaLamp.tsx
+++ b/app/components/lavaLamp.tsx
@@ -77,8 +77,14 @@ const LavaLamp = () => {
                     x2="0"
                     y2="280"
                 >
-                    <stop offset="0%" stopColor="#AAB2C6" />
-                    <stop offset="100%" stopColor="#223349" />
+                    <stop
+                        offset="0%"
+                        style={{ stopColor: 'var(--lava-top)' }}
+                    />
+                    <stop
+                        offset="100%"
+                        style={{ stopColor: 'var(--lava-bottom)' }}
+                    />
                 </linearGradient>
 
                 {/* Gooey filter so blobs merge into each other and the pool */}

--- a/app/components/leftSide/heading/Heading.tsx
+++ b/app/components/leftSide/heading/Heading.tsx
@@ -1,6 +1,7 @@
 'use client'
 import styles from '../../../styles/leftSide.module.css'
 import SideMenu from '../../sideMenu'
+import { ThemeToggle } from '../../themeToggle'
 import { motion } from 'framer-motion'
 import { useIsMobile } from '../../../hooks/useIsMobile'
 
@@ -19,7 +20,7 @@ export const Heading = () => {
         <div>
             <div
                 style={{
-                    backgroundColor: '#0D1B2A',
+                    backgroundColor: 'var(--bg)',
                     zIndex: 10,
                     width: '100%',
                     position: 'fixed',
@@ -28,9 +29,10 @@ export const Heading = () => {
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-                    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.35)',
+                    borderBottom: '1px solid var(--border)',
+                    boxShadow: '0 4px 20px rgba(0, 0, 0, 0.25)',
                     padding: '14px 0',
+                    transition: 'background-color 0.3s ease',
                 }}
             >
                 <motion.div whileHover={{ scale: 1.05, y: -2 }}>
@@ -54,7 +56,10 @@ export const Heading = () => {
                     </button>
                 </motion.div>
 
-                <SideMenu />
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <ThemeToggle />
+                    <SideMenu />
+                </div>
             </div>
         </div>
     ) : (

--- a/app/components/leftSide/navElements/NavElements.tsx
+++ b/app/components/leftSide/navElements/NavElements.tsx
@@ -1,52 +1,18 @@
 'use client'
 import styles from '../../../styles/leftSide.module.css'
 import { Line } from '../../line/Line'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { useIsMobile } from '../../../hooks/useIsMobile'
-
-const sections = ['about', 'experience', 'projects']
+import { SECTIONS, useActiveSection } from '../../../hooks/useActiveSection'
 
 export const NavElements = () => {
     const [target, setTarget] = useState('')
-    const [activeSection, setActiveSection] = useState('')
+    const activeSection = useActiveSection()
 
     const isMobile = useIsMobile()
 
-    useEffect(() => {
-        const handleScrollEvent = () => {
-            let maxVisible = { section: '', visibility: 0 }
-
-            sections.forEach((section) => {
-                const el = document.getElementById(section)
-                if (!el) return
-
-                const rect = el.getBoundingClientRect()
-                const visibleHeight = Math.max(
-                    0,
-                    Math.min(rect.bottom, window.innerHeight) -
-                        Math.max(rect.top, 0)
-                )
-
-                if (visibleHeight > maxVisible.visibility) {
-                    maxVisible = { section, visibility: visibleHeight }
-                }
-            })
-
-            if (maxVisible.section) {
-                setActiveSection(maxVisible.section)
-            }
-        }
-
-        window.addEventListener('scroll', handleScrollEvent)
-        handleScrollEvent() // Trigger on mount
-
-        return () => window.removeEventListener('scroll', handleScrollEvent)
-    }, [])
-
     const handleScroll = (section: string) => {
-        setActiveSection(section)
-
         // "About" is the first section, so go to the very top of the page;
         // the others land per the sections' scroll-margin-top
         if (section === 'about') {
@@ -58,7 +24,7 @@ export const NavElements = () => {
 
     return isMobile ? null : (
         <nav className={styles.nav_elements} aria-label="Section navigation">
-            {sections.map((section) => (
+            {SECTIONS.map((section) => (
                 <motion.button
                     key={section}
                     type="button"
@@ -80,15 +46,15 @@ export const NavElements = () => {
                     style={{
                         cursor: 'pointer',
                         // Same active treatment as the mobile menu:
-                        // coral text on a soft highlight pill
+                        // accent text on a soft highlight pill
                         background:
                             activeSection === section
-                                ? 'rgba(255, 255, 255, 0.08)'
+                                ? 'var(--surface)'
                                 : 'none',
                         color:
                             activeSection === section || target === section
-                                ? '#FF6F61'
-                                : '#fff', // Highlight active section
+                                ? 'var(--accent)'
+                                : 'var(--text)',
                     }}
                 >
                     <Line isHovered={target === section} />

--- a/app/components/leftSide/socialLinks/SocialLinks.tsx
+++ b/app/components/leftSide/socialLinks/SocialLinks.tsx
@@ -37,9 +37,9 @@ export const SocialLinks = () => {
 
     function handleColor(method: string) {
         if (isHovered === method) {
-            return '#FF6F61'
+            return 'var(--accent)'
         }
-        return '#4B88A2'
+        return 'var(--muted)'
     }
     return (
         <div

--- a/app/components/line/Line.tsx
+++ b/app/components/line/Line.tsx
@@ -6,7 +6,7 @@ export const Line = ({ isHovered }: { isHovered: boolean }) => {
         <div
             className={styles.line}
             style={{
-                background: isHovered ? '#FF6F61' : '#4B88A2',
+                background: isHovered ? 'var(--accent)' : 'var(--muted)',
             }}
         ></div>
     )

--- a/app/components/plusMinus.tsx
+++ b/app/components/plusMinus.tsx
@@ -18,7 +18,7 @@ const PlusMinus = ({ isOpen }: Props) => {
                 y1="12"
                 x2="19"
                 y2="12"
-                stroke="white"
+                stroke="currentColor"
                 strokeWidth="2"
                 initial={{ opacity: 1 }}
                 animate={{ opacity: 1 }}
@@ -28,7 +28,7 @@ const PlusMinus = ({ isOpen }: Props) => {
                 y1="5"
                 x2="12"
                 y2="19"
-                stroke="white"
+                stroke="currentColor"
                 strokeWidth="2"
                 initial={{ opacity: 1 }}
                 animate={{ opacity: isOpen ? 0 : 1 }}

--- a/app/components/rightSide/Projects/Project.tsx
+++ b/app/components/rightSide/Projects/Project.tsx
@@ -43,8 +43,8 @@ export const Project = ({ project }: Props) => {
                     alignItems: 'center',
                     padding: '12px',
                     borderRadius: '16px',
-                    border: '1px solid rgba(255, 255, 255, 0.1)',
-                    background: 'rgba(255, 255, 255, 0.05)',
+                    border: '1px solid var(--border)',
+                    background: 'var(--surface-dim)',
                     flexShrink: 0,
                 }}
             >

--- a/app/components/rightSide/experience/Experience.tsx
+++ b/app/components/rightSide/experience/Experience.tsx
@@ -125,21 +125,10 @@ export const Experience = () => {
                 return (
                     <motion.div
                         key={job.id}
+                        className={styles.job_card}
                         initial={{ opacity: 0, y: 20 }}
                         whileInView={{ opacity: 1, y: 0 }}
-                        whileHover={{
-                            backgroundColor: 'rgba(255, 255, 255, 0.18)',
-                        }}
-                        transition={{
-                            duration: 0.6,
-                            backgroundColor: { duration: 0.2 },
-                        }}
-                        style={{
-                            backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                            padding: '8px',
-                            borderRadius: '16px',
-                            cursor: 'pointer',
-                        }}
+                        transition={{ duration: 0.6 }}
                     >
                         <Job job={job} />
                     </motion.div>

--- a/app/components/sideMenu.tsx
+++ b/app/components/sideMenu.tsx
@@ -2,15 +2,16 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { SocialLinks } from './leftSide/socialLinks/SocialLinks'
-const navItems = [
-    { id: 'about', label: 'About' },
-    { id: 'experience', label: 'Experience' },
-    { id: 'projects', label: 'Projects' },
-]
+import { SECTIONS, useActiveSection } from '../hooks/useActiveSection'
+
+const navItems = SECTIONS.map((id) => ({
+    id,
+    label: id.charAt(0).toUpperCase() + id.slice(1),
+}))
 
 const SideMenu = () => {
     const [isOpen, setIsOpen] = useState(false)
-    const [activeSection, setActiveSection] = useState('about')
+    const activeSection = useActiveSection()
     // Section to scroll to once the menu closes — scrolling can't happen
     // while the body scroll lock is still active
     const pendingSection = useRef<string | null>(null)
@@ -49,26 +50,6 @@ const SideMenu = () => {
         setIsOpen(false)
     }
 
-    // Detect active section while scrolling
-    useEffect(() => {
-        const observer = new IntersectionObserver(
-            (entries) => {
-                entries.forEach((entry) => {
-                    if (entry.isIntersecting) {
-                        setActiveSection(entry.target.id)
-                    }
-                })
-            },
-            { threshold: 0.5 }
-        )
-
-        document
-            .querySelectorAll('section')
-            .forEach((section) => observer.observe(section))
-
-        return () => observer.disconnect()
-    }, [])
-
     return (
         <div
             style={{
@@ -87,13 +68,14 @@ const SideMenu = () => {
                         cursor: 'pointer',
                         padding: '8px',
                         display: 'flex',
+                        color: 'var(--text)',
                     }}
                 >
                     <svg
                         width="28"
                         height="28"
                         viewBox="0 0 24 24"
-                        stroke="white"
+                        stroke="currentColor"
                         strokeWidth="2"
                         strokeLinecap="round"
                         aria-hidden="true"
@@ -118,7 +100,7 @@ const SideMenu = () => {
                             style={{
                                 position: 'fixed',
                                 inset: 0,
-                                backgroundColor: 'rgba(4, 10, 18, 0.6)',
+                                backgroundColor: 'var(--backdrop)',
                                 backdropFilter: 'blur(2px)',
                                 zIndex: 39,
                             }}
@@ -145,11 +127,10 @@ const SideMenu = () => {
                                 height: '100%',
                                 width: 'min(280px, 80vw)',
                                 padding: '16px 24px 32px',
-                                backgroundColor: '#132435',
-                                borderLeft:
-                                    '1px solid rgba(255, 255, 255, 0.1)',
-                                boxShadow: '-16px 0 40px rgba(0, 0, 0, 0.5)',
-                                color: '#F5F5F4',
+                                backgroundColor: 'var(--panel-bg)',
+                                borderLeft: '1px solid var(--border)',
+                                boxShadow: '-16px 0 40px rgba(0, 0, 0, 0.3)',
+                                color: 'var(--text)',
                                 display: 'flex',
                                 flexDirection: 'column',
                             }}
@@ -161,7 +142,7 @@ const SideMenu = () => {
                                     alignSelf: 'flex-end',
                                     background: 'transparent',
                                     border: 'none',
-                                    color: '#AAB2C6',
+                                    color: 'var(--heading-muted)',
                                     cursor: 'pointer',
                                     fontSize: '24px',
                                     padding: '8px',
@@ -198,15 +179,15 @@ const SideMenu = () => {
                                             borderRadius: '12px',
                                             background:
                                                 activeSection === id
-                                                    ? 'rgba(255, 255, 255, 0.08)'
+                                                    ? 'var(--surface)'
                                                     : 'none',
                                             border: 'none',
                                             fontFamily: 'inherit',
                                             fontWeight: 300,
                                             color:
                                                 activeSection === id
-                                                    ? '#FF6F61'
-                                                    : '#F5F5F4',
+                                                    ? 'var(--accent)'
+                                                    : 'var(--text)',
                                             transition:
                                                 'color 0.2s ease, background 0.2s ease',
                                         }}
@@ -220,8 +201,7 @@ const SideMenu = () => {
                                 style={{
                                     marginTop: 'auto',
                                     paddingTop: '24px',
-                                    borderTop:
-                                        '1px solid rgba(255, 255, 255, 0.1)',
+                                    borderTop: '1px solid var(--border)',
                                     display: 'flex',
                                     justifyContent: 'center',
                                 }}

--- a/app/components/themeToggle.tsx
+++ b/app/components/themeToggle.tsx
@@ -1,0 +1,97 @@
+'use client'
+import { useSyncExternalStore } from 'react'
+import { motion } from 'framer-motion'
+
+type Theme = 'dark' | 'light'
+
+// The theme lives on <html data-theme> (set pre-paint by the init script in
+// layout.tsx); this tiny store lets React subscribe to it without effects
+let listeners: Array<() => void> = []
+
+const subscribe = (listener: () => void) => {
+    listeners.push(listener)
+    return () => {
+        listeners = listeners.filter((l) => l !== listener)
+    }
+}
+
+const getTheme = (): Theme =>
+    document.documentElement.dataset.theme === 'light' ? 'light' : 'dark'
+
+const setTheme = (theme: Theme) => {
+    document.documentElement.dataset.theme = theme
+    try {
+        localStorage.setItem('theme', theme)
+    } catch {
+        // Persistence is best-effort; the in-page theme still applies
+    }
+    listeners.forEach((listener) => listener())
+}
+
+const SunIcon = () => (
+    <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        aria-hidden="true"
+    >
+        <circle cx="12" cy="12" r="4" />
+        <line x1="12" y1="2" x2="12" y2="5" />
+        <line x1="12" y1="19" x2="12" y2="22" />
+        <line x1="2" y1="12" x2="5" y2="12" />
+        <line x1="19" y1="12" x2="22" y2="12" />
+        <line x1="4.9" y1="4.9" x2="7" y2="7" />
+        <line x1="17" y1="17" x2="19.1" y2="19.1" />
+        <line x1="4.9" y1="19.1" x2="7" y2="17" />
+        <line x1="17" y1="7" x2="19.1" y2="4.9" />
+    </svg>
+)
+
+const MoonIcon = () => (
+    <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+    >
+        <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+    </svg>
+)
+
+export const ThemeToggle = () => {
+    const theme = useSyncExternalStore(subscribe, getTheme, () => 'dark')
+
+    const nextTheme: Theme = theme === 'dark' ? 'light' : 'dark'
+
+    const toggle = () => {
+        setTheme(nextTheme)
+    }
+
+    return (
+        <motion.button
+            type="button"
+            onClick={toggle}
+            whileHover={{ scale: 1.1, y: -2 }}
+            aria-label={`Switch to ${nextTheme} theme`}
+            style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: 'var(--text)',
+                padding: '8px',
+                display: 'flex',
+            }}
+        >
+            {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+        </motion.button>
+    )
+}

--- a/app/hooks/useActiveSection.ts
+++ b/app/hooks/useActiveSection.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+export const SECTIONS = ['about', 'experience', 'projects'] as const
+
+// A section counts as active once its top has scrolled past a line 25% down
+// the viewport. Unlike visibility-ratio approaches, this works for sections
+// taller than the viewport and always agrees with where nav clicks land.
+export const useActiveSection = () => {
+    const [activeSection, setActiveSection] = useState<string>(SECTIONS[0])
+
+    useEffect(() => {
+        const update = () => {
+            const refLine = window.innerHeight * 0.25
+            let current: string = SECTIONS[0]
+            for (const id of SECTIONS) {
+                const el = document.getElementById(id)
+                if (el && el.getBoundingClientRect().top <= refLine) {
+                    current = id
+                }
+            }
+            setActiveSection(current)
+        }
+
+        update()
+        window.addEventListener('scroll', update, { passive: true })
+        window.addEventListener('resize', update)
+        return () => {
+            window.removeEventListener('scroll', update)
+            window.removeEventListener('resize', update)
+        }
+    }, [])
+
+    return activeSection
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,10 +26,26 @@ interface Props {
     readonly children: ReactNode
 }
 
+// Runs before first paint so the stored/system theme applies with no flash
+const themeInitScript = `(function () {
+    try {
+        var theme = localStorage.getItem('theme')
+        if (theme !== 'light' && theme !== 'dark') {
+            theme = window.matchMedia('(prefers-color-scheme: light)').matches
+                ? 'light'
+                : 'dark'
+        }
+        document.documentElement.dataset.theme = theme
+    } catch (e) {
+        document.documentElement.dataset.theme = 'dark'
+    }
+})()`
+
 export default function RootLayout({ children }: Props) {
     return (
-        <html lang="en">
+        <html lang="en" suppressHydrationWarning>
             <body>
+                <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
                 <main>{children}</main>
             </body>
         </html>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -19,7 +19,7 @@ export default function NotFound() {
                     fontSize: 96,
                     fontWeight: 600,
                     margin: 0,
-                    color: '#AAB2C6',
+                    color: 'var(--heading-muted)',
                 }}
             >
                 404
@@ -33,8 +33,8 @@ export default function NotFound() {
                     marginTop: '16px',
                     padding: '10px 24px',
                     borderRadius: '16px',
-                    background: 'rgba(255, 255, 255, 0.1)',
-                    color: '#FF6F61',
+                    background: 'var(--surface)',
+                    color: 'var(--accent)',
                     fontSize: 18,
                 }}
             >

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,14 +1,53 @@
+:root {
+    color-scheme: dark;
+
+    --bg: #0d1b2a;
+    --text: #f5f5f4;
+    --accent: #ff6f61;
+    --muted: #4b88a2;
+    --heading-muted: #aab2c6;
+    --surface: rgba(255, 255, 255, 0.08);
+    --surface-dim: rgba(255, 255, 255, 0.05);
+    --surface-hover: rgba(255, 255, 255, 0.16);
+    --border: rgba(255, 255, 255, 0.1);
+    --panel-bg: #132435;
+    --backdrop: rgba(4, 10, 18, 0.6);
+    --lava-top: #aab2c6;
+    --lava-bottom: #223349;
+}
+
+[data-theme='light'] {
+    color-scheme: light;
+
+    --bg: #f4f6fa;
+    --text: #1b2a3a;
+    --accent: #d6493c;
+    --muted: #4b88a2;
+    --heading-muted: #8a94a8;
+    --surface: rgba(13, 27, 42, 0.07);
+    --surface-dim: rgba(13, 27, 42, 0.04);
+    --surface-hover: rgba(13, 27, 42, 0.13);
+    --border: rgba(13, 27, 42, 0.15);
+    --panel-bg: #ffffff;
+    --backdrop: rgba(20, 30, 45, 0.35);
+    --lava-top: #8fa3c0;
+    --lava-bottom: #e4e9f2;
+}
+
 html,
 body {
     padding: 0;
     margin: 0;
     font-family:
         'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    background: #0d1b2a;
-    color: #f5f5f4;
+    background: var(--bg);
+    color: var(--text);
     font-weight: 200;
     font-size: 18px;
     font-kerning: normal;
+    transition:
+        background-color 0.3s ease,
+        color 0.3s ease;
 }
 
 a {
@@ -21,7 +60,7 @@ a {
 }
 
 :focus-visible {
-    outline: 2px solid #ff6f61;
+    outline: 2px solid var(--accent);
     outline-offset: 3px;
     border-radius: 2px;
 }

--- a/app/styles/rightSide.module.css
+++ b/app/styles/rightSide.module.css
@@ -11,10 +11,10 @@
     gap: 80px;
 }
 
-/* Landing offset for nav scroll: keeps section headings comfortably below
-   the top of the viewport (and clear of the fixed header on mobile) */
+/* Landing offset for nav scroll: aligns section headings with the top of
+   the viewport (and clear of the fixed header on mobile) */
 .right section {
-    scroll-margin-top: 18vh;
+    scroll-margin-top: 24px;
 }
 
 /* Mobile styles */
@@ -42,6 +42,18 @@
     gap: 10px;
 }
 
+.job_card {
+    background: var(--surface);
+    padding: 8px;
+    border-radius: 16px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.job_card:hover {
+    background: var(--surface-hover);
+}
+
 .job_dates {
     min-width: 120px;
 }
@@ -60,7 +72,7 @@
 
 .skill {
     border-radius: 1em;
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--surface);
     padding: 10px;
     font-size: 14px;
     width: fit-content;

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -27,13 +27,47 @@ test('experience accordion expands and collapses', async ({ page }) => {
     await expect(firstJob).toHaveAttribute('aria-expanded', 'false')
 })
 
-test('section navigation scrolls the page', async ({ page }) => {
+test('section navigation lands headers at the top and swaps the highlight', async ({
+    page,
+}) => {
     await page.goto('/')
 
-    await page.getByRole('button', { name: 'Projects' }).click()
-    await page.waitForTimeout(1000) // allow smooth scroll to finish
-    const scrollY = await page.evaluate(() => window.scrollY)
-    expect(scrollY).toBeGreaterThan(0)
+    const projectsButton = page.getByRole('button', { name: 'Projects' })
+    await projectsButton.click()
+    await page.waitForTimeout(1200) // allow smooth scroll to finish
+
+    // Section header aligned near the top of the viewport
+    const sectionTop = await page.evaluate(
+        () => document.getElementById('projects')!.getBoundingClientRect().top
+    )
+    expect(sectionTop).toBeGreaterThan(-5)
+    expect(sectionTop).toBeLessThan(120)
+
+    // Highlight follows the scroll position
+    await expect(projectsButton).toHaveAttribute('aria-current', 'true')
+    await expect(
+        page.getByRole('button', { name: 'Experience' })
+    ).not.toHaveAttribute('aria-current', 'true')
+})
+
+test('theme toggle switches and persists across reloads', async ({ page }) => {
+    await page.goto('/')
+
+    const initial = await page.evaluate(
+        () => document.documentElement.dataset.theme
+    )
+    expect(['dark', 'light']).toContain(initial)
+
+    const other = initial === 'dark' ? 'light' : 'dark'
+    await page.getByRole('button', { name: `Switch to ${other} theme` }).click()
+    await expect
+        .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+        .toBe(other)
+
+    await page.reload()
+    await expect
+        .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+        .toBe(other)
 })
 
 test.describe('mobile viewport', () => {
@@ -56,6 +90,12 @@ test.describe('mobile viewport', () => {
         // Fixed header is ~73px tall; scroll-margin-top places sections at 84px
         expect(sectionTop).toBeGreaterThan(73)
         expect(sectionTop).toBeLessThan(150)
+
+        // Reopen the menu: the highlight should have followed the scroll
+        await page.getByRole('button', { name: 'Open navigation menu' }).click()
+        await expect(
+            page.getByRole('button', { name: 'Experience' })
+        ).toHaveAttribute('aria-current', 'true')
     })
 })
 


### PR DESCRIPTION
## Summary

### Light/dark mode
- Palette converted to CSS custom properties (`--bg`, `--text`, `--accent`, `--surface`, `--border`, …) with a light override on `[data-theme='light']`
- Sun/moon toggle: fixed top-right on desktop, in the header bar on mobile; persists to localStorage and defaults to the system preference
- An inline script in the layout applies the theme before first paint — no flash of the wrong theme; the toggle reads the `<html>` attribute via `useSyncExternalStore`
- Everything is themed: nav pills, job cards, skill chips, project frames, mobile menu, lava lamp gradient, hamburger/plus icons, 404 page; light mode uses a slightly darker coral (`#D6493C`) for contrast

### Active-nav highlight fix (both viewports)
Both navs disagreed with real scroll position:
- The mobile menu's IntersectionObserver required 50% of a section visible — sections taller than the viewport **never** reach that, so the highlight never moved
- The desktop "most visible section" heuristic could lag clicks

Both now share one `useActiveSection` hook: active = the last section whose top has passed a line 25% down the viewport. Consistent with click landings, works for tall sections, updates live while scrolling.

### Top-aligned scroll landing
Desktop `scroll-margin-top` drops from `18vh` to `24px` — a clicked section's header now sits at the top of the view instead of showing the previous section's tail. Mobile keeps `84px` to clear the fixed header.

## Testing
- Measured after-click landings: desktop 24px, mobile 84px; highlight verified to follow both clicks and free scrolling (including scrolled-to-bottom → Projects active)
- Verified light + dark rendering on desktop and mobile (screenshots), system-preference pickup, and persistence across reload
- 6/6 Playwright smoke tests (two new: theme toggle persistence, highlight swap assertions); lint, typecheck, and production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_