### PR TITLE
Link project tiles to live deployments

### DIFF
--- a/app/components/rightSide/Projects/Project.tsx
+++ b/app/components/rightSide/Projects/Project.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { motion } from 'framer-motion'
 import Image from 'next/image'
 import styles from '../../../styles/rightSide.module.css'
 import { useIsMobile } from '../../../hooks/useIsMobile'
@@ -22,17 +21,17 @@ interface Props {
 export const Project = ({ project }: Props) => {
     const isMobile = useIsMobile()
 
-    return (
-        <motion.div
-            style={{
-                display: 'flex',
-                flexDirection: isMobile ? 'column-reverse' : 'row',
-                alignItems: 'center',
-                gap: isMobile ? 0 : 50,
-                padding: '8px',
-                height: isMobile ? 'unset' : '250px',
-            }}
-        >
+    const tileStyle = {
+        display: 'flex',
+        flexDirection: isMobile ? 'column-reverse' : 'row',
+        alignItems: 'center',
+        gap: isMobile ? 0 : 50,
+        padding: '8px',
+        height: isMobile ? 'unset' : '250px',
+    } as const
+
+    const tileContent = (
+        <>
             <div
                 style={{
                     width: '100%',
@@ -48,12 +47,8 @@ export const Project = ({ project }: Props) => {
                     flexShrink: 0,
                 }}
             >
-                <a
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                <div
                     style={{
-                        display: 'block',
                         position: 'relative',
                         width: '100%',
                         height: '100%',
@@ -69,7 +64,7 @@ export const Project = ({ project }: Props) => {
                             borderRadius: '8px',
                         }}
                     />
-                </a>
+                </div>
             </div>
             <div
                 style={{
@@ -140,6 +135,21 @@ export const Project = ({ project }: Props) => {
                     </div>
                 </div>
             </div>
-        </motion.div>
+        </>
+    )
+
+    // The whole tile is a link to the live project when a URL exists
+    return project.url ? (
+        <a
+            href={project.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${project.title} (opens in new tab)`}
+            style={{ ...tileStyle, cursor: 'pointer' }}
+        >
+            {tileContent}
+        </a>
+    ) : (
+        <div style={tileStyle}>{tileContent}</div>
     )
 }

--- a/app/components/rightSide/Projects/Projects.tsx
+++ b/app/components/rightSide/Projects/Projects.tsx
@@ -11,6 +11,7 @@ export const Projects = () => {
             title: "Del's",
             text: 'Website for an up and coming speakeasy in New York City',
             image: '/del.jpeg',
+            url: 'https://dels-9hki.vercel.app/',
             id: 'del',
             skills: ['NextJS', 'Tailwind CSS', 'TypeScript'],
         },
@@ -26,6 +27,7 @@ export const Projects = () => {
             title: 'Breath of the Wild Cooking App',
             text: 'Cooking mini-game with an in-game shop. Buy ingredients and cook them!',
             image: '/botw.jpeg',
+            url: 'https://botw-recipe-app.vercel.app/',
             frontend: 'https://github.com/dylantoporek/botw-recipe-app',
             backend: 'https://github.com/dylantoporek/botw-recipe-app-backend',
             id: 'botw',
@@ -41,6 +43,7 @@ export const Projects = () => {
             title: 'Pokemon Minigame App',
             text: 'Collection of Pokemon themed mini-games. Race on the track or battle in the arena!',
             image: '/pokemon.jpeg',
+            url: 'https://pokemon-minigame-project.vercel.app/',
             frontend:
                 'https://github.com/dylantoporek/pokemon-mini-game-project',
             backend: 'https://github.com/dylantoporek/pokemon-minigame-backend',


### PR DESCRIPTION
## Summary

- Adds live deployment URLs to the project data:
  - Del's → https://dels-9hki.vercel.app/
  - Pokemon Minigame App → https://pokemon-minigame-project.vercel.app/
  - BOTW Cooking App → https://botw-recipe-app.vercel.app/
- Each project tile is now one clickable anchor that opens the live site in a new tab (`target="_blank"` + `rel="noopener noreferrer"`), replacing the previous image-only link — no visual changes otherwise
- Tiles without a URL render exactly as before, unlinked
- Links carry accessible names (`"<title> (opens in new tab)"`)

## Testing
- Verified all four tiles render with the correct href/target/rel and that clicking opens a popup
- 6/6 Playwright smoke tests passing; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_