### PR TITLE
Add Made With chips to the Cinema Shirts tile

### DIFF
--- a/app/components/rightSide/Projects/Projects.tsx
+++ b/app/components/rightSide/Projects/Projects.tsx
@@ -13,7 +13,7 @@ export const Projects = () => {
             image: '/cinemashirts.png',
             url: 'https://www.cinemashirts.com/',
             id: 'cinema-shirts',
-            skills: [],
+            skills: ['NextJS', 'React', 'TypeScript', 'Tailwind CSS', 'Stripe'],
         },
         {
             title: "Del's",


### PR DESCRIPTION
## Summary

Fills in the Cinema Shirts tile's "Made With" chips using the actual stack from the [Cinema-Shirts repo](https://github.com/dylantoporek/Cinema-Shirts)'s `package.json`: **NextJS, React, TypeScript, Tailwind CSS, Stripe**.

One-line data change; chip naming matches the style used on the other tiles.

## Testing
- Lint, typecheck, and 6/6 Playwright smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_