### PR TITLE
Update Made With chips to match each project's current stack

### DIFF
--- a/app/components/rightSide/Projects/Projects.tsx
+++ b/app/components/rightSide/Projects/Projects.tsx
@@ -21,7 +21,7 @@ export const Projects = () => {
             image: '/del.jpeg',
             url: 'https://dels-9hki.vercel.app/',
             id: 'del',
-            skills: ['NextJS', 'Tailwind CSS', 'TypeScript'],
+            skills: ['NextJS', 'React', 'TypeScript', 'Tailwind CSS'],
         },
         {
             title: 'Portfolio Version 1',
@@ -41,10 +41,11 @@ export const Projects = () => {
             id: 'botw',
             skills: [
                 'React',
-                'Ruby on Rails',
-                'CSS',
-                'Chakra UI',
                 'JavaScript',
+                'Chakra UI',
+                'Node.js',
+                'Express',
+                'PostgreSQL',
             ],
         },
         {
@@ -57,10 +58,12 @@ export const Projects = () => {
             id: 'board-game',
             skills: [
                 'React',
-                'Ruby on Rails',
-                'CSS',
-                'Chakra UI',
                 'JavaScript',
+                'Bootstrap',
+                'Sass',
+                'Node.js',
+                'Express',
+                'PostgreSQL',
             ],
         },
         {
@@ -72,7 +75,14 @@ export const Projects = () => {
                 'https://github.com/dylantoporek/pokemon-mini-game-project',
             backend: 'https://github.com/dylantoporek/pokemon-minigame-backend',
             id: 'poke',
-            skills: ['React', 'Ruby on Rails', 'CSS', 'JavaScript'],
+            skills: [
+                'React',
+                'JavaScript',
+                'CSS',
+                'Node.js',
+                'Express',
+                'PostgreSQL',
+            ],
         },
     ]
 


### PR DESCRIPTION
## Summary

Audited every project's actual repo manifests and updated the "Made With" chips to match reality:

| Project | Before | After |
| --- | --- | --- |
| Del's | NextJS, Tailwind CSS, TypeScript | NextJS, **React**, TypeScript, Tailwind CSS |
| BOTW Cooking App | React, ~~Ruby on Rails~~, CSS, Chakra UI, JavaScript | React, JavaScript, Chakra UI, **Node.js, Express, PostgreSQL** |
| Nintendo-Land | React, ~~Ruby on Rails~~, CSS, ~~Chakra UI~~, JavaScript | React, JavaScript, **Bootstrap, Sass**, **Node.js, Express, PostgreSQL** |
| Pokemon Minigame App | React, ~~Ruby on Rails~~, CSS, JavaScript | React, JavaScript, CSS, **Node.js, Express, PostgreSQL** |

Key findings from the audit:
- All three game-app backends (`Board-Game-Backend`, `botw-recipe-app-backend`, `pokemon-minigame-backend`) were ported in the last few days from Ruby on Rails to **Node/Express with PostgreSQL** (their package.json descriptions say so explicitly: "Node/Express port of the original Rails backend, deployable to Vercel") — so the Rails chips were stale
- Nintendo-Land's old chips claimed Chakra UI, but its package.json shows **Bootstrap + Sass**
- Del's is Next 16 / React 19 / Tailwind 4 / TypeScript

Portfolio v1 left untouched as requested; Cinema Shirts was already accurate from #16.

## Testing
- Lint, typecheck, and 6/6 Playwright smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtV2T7m5LyacrUcaoSqmn)_